### PR TITLE
[#11] Task01/hide complete group

### DIFF
--- a/holdy-iOS/Presentation/GeneratingGroup/View/GeneratingGroupViewController.swift
+++ b/holdy-iOS/Presentation/GeneratingGroup/View/GeneratingGroupViewController.swift
@@ -531,7 +531,6 @@ final class GeneratingGroupViewController: UIViewController {
                 }
                 
                 self.dismiss(animated: true)
-                
             })
             .disposed(by: disposeBag)
     }

--- a/holdy-iOS/Presentation/Home/View/GroupListViewController.swift
+++ b/holdy-iOS/Presentation/Home/View/GroupListViewController.swift
@@ -58,6 +58,7 @@ final class GroupListViewController: UIViewController {
     // MARK: - Properties
     private var viewModel: GroupListViewModel!
     private var coordinator: HomeCoordinator!
+    private var isFirstLoad = true
     private let disposeBag = DisposeBag()
     
     convenience init(viewModel: GroupListViewModel, coordinator: HomeCoordinator) {
@@ -79,8 +80,13 @@ final class GroupListViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
-        listCollectionview.reloadData()
+        
+        if !isFirstLoad {
+            listCollectionview.reloadData()
+            listCollectionview.scrollToItem(at: IndexPath(item: .zero, section: .zero), at: .top, animated: true)
+        }
+        
+        isFirstLoad = false
     }
     
     // MARK: - Methods

--- a/holdy-iOS/Presentation/Home/ViewModel/GroupListViewModel.swift
+++ b/holdy-iOS/Presentation/Home/ViewModel/GroupListViewModel.swift
@@ -10,17 +10,18 @@ import RxSwift
 
 final class GroupListViewModel {
     struct Input {
-        let viewWillAppear: Observable<Bool>
+        let loadDataWithViewWillAppear: Observable<Bool>
     }
     
     struct Output {
         let groupInfos: Observable<[GroupInfo]>
     }
     
+    private(set) var isFiltered = false
     private let router = GroupListRouter()
     
     func transform(_ input: Input) -> Output {
-        let groupInfos = configureGroupInfos(with: input.viewWillAppear)
+        let groupInfos = configureGroupInfos(with: input.loadDataWithViewWillAppear)
         let output = Output(
             groupInfos: groupInfos
         )
@@ -31,7 +32,11 @@ final class GroupListViewModel {
     private func configureGroupInfos(with inputObserver: Observable<Bool>) -> Observable<[GroupInfo]> {
         inputObserver
             .withUnretained(self)
-            .flatMap { (viewModel, _) -> Single<GroupInfoResponse> in
+            .flatMap { (viewModel, isViewWillAppearCalled) -> Single<GroupInfoResponse> in
+                if !isViewWillAppearCalled {
+                    viewModel.isFiltered.toggle()
+                }
+                
                 let response = viewModel.router.requestGroupList(
                     api: HoldyAPI.GetGroupList(),
                     decodingType: GroupInfoResponse.self
@@ -39,7 +44,14 @@ final class GroupListViewModel {
                 
                 return response
             }
-            .map { groupInfoResponse in
+            .withUnretained(self)
+            .map { viewModel, groupInfoResponse in
+                if viewModel.isFiltered {
+                    return groupInfoResponse.data.filter { groupInfo in
+                        groupInfo.isEnd == false
+                    }
+                }
+                
                 return groupInfoResponse.data
             }
     }


### PR DESCRIPTION
# 배경
홈 화면에서 `끝난 모임 숨기기` 버튼을 구현하지 않아 추가로 구현

# 작업 내용
## 1. 데이터를 부르는 로직 변경 
기존에는 viewWillAppear가 호출될 때 데이터를 새롭게 불러오는 방식을 선택했다. 이전에는 처음에 화면을 불러올 때와 모임 생성을 했을 때에만 다시 데이터를 새로 불러오면 됐기 때문이다. 

하지만 `끝난 모임 숨기기` 버튼을 눌렀을 때 끝난 모임을 filter해서 새롭게 보여줘야 했다. 따라서 viewWillAppear일 때만 새롭게 데이터를 불러오는 것이 아니라 `loadDataWithViewWillAppear`를 통해 viewWillAppear일 때와 `끝난 모임 숨기기` 버튼을 눌렀을 때 데이터를 새롭게 불러올 수 있도록 수정했다. 

또한 viewWillAppear일 때는 따로 필터를 해줄 필요가 없어서 이를 구분하기 위해 Bool 타입을 전달해서 이를 파악할 수 있도록 해주었다. 

- viewWillAppear일 때: `loadDataWithViewWillAppear` -> true를 보냄
- `끝난 모임 숨기기` 버튼을 눌렀을 때: `loadDataWithViewWillAppear` -> false를 보냄

# 테스트 방법
시간 관계 상 따로 테스트 코드를 짜지 않고 시뮬레이터를 통해 직접 확인

# 리뷰 노트
- 지금 구현상황으로는 항상 앱을 재실행하는 경우 끝난 모임 숨기기 버튼이 false로 돌아가게 된다.

# 스크린샷
생략

