### PR TITLE
[Feature] 카카오톡 공유를 통해 앱에 접속했을 때 모임이 추가되도록 구현

### DIFF
--- a/holdy-iOS.xcodeproj/project.pbxproj
+++ b/holdy-iOS.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		DEB7D3FE28E96D4E00E0C47E /* RewardDetailRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB7D3FD28E96D4E00E0C47E /* RewardDetailRouter.swift */; };
 		DEB7D40028E9710200E0C47E /* RewardDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB7D3FF28E9710200E0C47E /* RewardDetailViewController.swift */; };
 		DEB7D40228E982EB00E0C47E /* RewardDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB7D40128E982EB00E0C47E /* RewardDetailViewModel.swift */; };
+		DEB7D40528EAEBC000E0C47E /* InvitationRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB7D40428EAEBC000E0C47E /* InvitationRouter.swift */; };
 		DEB8CF8628D44A0E00F3C967 /* ReportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB8CF8528D44A0E00F3C967 /* ReportViewModel.swift */; };
 		DEE002ED28C2401400D4896C /* KakaoSDKShare in Frameworks */ = {isa = PBXBuildFile; productRef = DEE002EC28C2401400D4896C /* KakaoSDKShare */; };
 		DEE002EF28C2401400D4896C /* KakaoSDKTemplate in Frameworks */ = {isa = PBXBuildFile; productRef = DEE002EE28C2401400D4896C /* KakaoSDKTemplate */; };
@@ -194,6 +195,7 @@
 		DEB7D3FD28E96D4E00E0C47E /* RewardDetailRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardDetailRouter.swift; sourceTree = "<group>"; };
 		DEB7D3FF28E9710200E0C47E /* RewardDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardDetailViewController.swift; sourceTree = "<group>"; };
 		DEB7D40128E982EB00E0C47E /* RewardDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardDetailViewModel.swift; sourceTree = "<group>"; };
+		DEB7D40428EAEBC000E0C47E /* InvitationRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvitationRouter.swift; sourceTree = "<group>"; };
 		DEB8CF8528D44A0E00F3C967 /* ReportViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -306,6 +308,7 @@
 		DE16E75F2895284200C75C23 /* App */ = {
 			isa = PBXGroup;
 			children = (
+				DEB7D40328EAEBAE00E0C47E /* Router */,
 				DE16E74B2895271B00C75C23 /* AppDelegate.swift */,
 				DE16E74D2895271B00C75C23 /* SceneDelegate.swift */,
 			);
@@ -715,6 +718,14 @@
 			path = Router;
 			sourceTree = "<group>";
 		};
+		DEB7D40328EAEBAE00E0C47E /* Router */ = {
+			isa = PBXGroup;
+			children = (
+				DEB7D40428EAEBC000E0C47E /* InvitationRouter.swift */,
+			);
+			path = Router;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -911,6 +922,7 @@
 				DE2024FE28A8DD10004B4F59 /* NetworkConnectionManager.swift in Sources */,
 				DE15223728ADFEFE0048C07B /* GroupDetailViewModel.swift in Sources */,
 				DE16E7B0289556BE00C75C23 /* LoginRouter.swift in Sources */,
+				DEB7D40528EAEBC000E0C47E /* InvitationRouter.swift in Sources */,
 				DE16E7B4289558A000C75C23 /* HoldyAPI.swift in Sources */,
 				9B29173328A9450700CFFDEA /* GroupListViewController.swift in Sources */,
 				DE2024E028A2A7E9004B4F59 /* GeneratingGroupRouter.swift in Sources */,

--- a/holdy-iOS/App/Router/InvitationRouter.swift
+++ b/holdy-iOS/App/Router/InvitationRouter.swift
@@ -1,0 +1,44 @@
+//
+//  Created by 양호준 on 2022/10/03.
+//
+
+import Foundation
+
+import Alamofire
+import RxSwift
+
+struct InvitationpRouter {
+    func reqeustInvitation<T: Decodable>(api: Requestable, id: Int, decodingType: T.Type) -> Single<T> {
+        return Single.create { emitter in
+            let loginSessionValue = String(describing: UserDefaultsManager.loginSession)
+            let headers: HTTPHeaders = [
+                "Accept": api.contentType ?? "",
+                "Cookie": "SESSION=\(loginSessionValue)"
+            ]
+            let httpMethod = HTTPMethod(rawValue: api.method.description)
+            let bodyParams: Parameters = [
+                "meetingId": id
+            ]
+            
+            AF
+                .request(
+                    api.url ?? URL(fileURLWithPath: ""),
+                    method: httpMethod,
+                    parameters: bodyParams,
+                    encoding: JSONEncoding.default,
+                    headers: headers
+                )
+                .validate(statusCode: 200..<300)
+                .responseDecodable(of: T.self) { response in
+                    switch response.result {
+                    case .success(let data):
+                        emitter(.success(data))
+                    case .failure(let error):
+                        emitter(.failure(error))
+                    }
+                }
+            
+            return Disposables.create()
+        }
+    }
+}

--- a/holdy-iOS/App/SceneDelegate.swift
+++ b/holdy-iOS/App/SceneDelegate.swift
@@ -35,11 +35,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func sceneWillResignActive(_ scene: UIScene) { }
 
-    func sceneWillEnterForeground(_ scene: UIScene) { }
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        NotificationCenter.default.post(name: NSNotification.Name("EnterForeground"), object: nil)
+    }
 
     func sceneDidEnterBackground(_ scene: UIScene) { }
     
     // MARK: - Kakao Link
+    // TODO: - 에러 메세지를 보여주는 로직 구현
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         if let url = URLContexts.first?.url {
             let query = url.query

--- a/holdy-iOS/App/SceneDelegate.swift
+++ b/holdy-iOS/App/SceneDelegate.swift
@@ -4,9 +4,13 @@
 
 import UIKit
 
+import RxSwift
+
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     var window: UIWindow?
     var appCoordinator: AppCoordinator?
+    private let router = InvitationpRouter()
+    private let disposeBag = DisposeBag()
 
     func scene(
         _ scene: UIScene,
@@ -38,8 +42,26 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // MARK: - Kakao Link
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         if let url = URLContexts.first?.url {
-            // TODO: 나중에 링크 연결할 수 있도록 수정
-            print(url)
+            let query = url.query
+            if let range = query?.range(of: "="), var query = query {
+                query.removeSubrange(query.startIndex...range.lowerBound)
+                
+                guard let id = Int(query) else { return }
+                
+                let response = router.reqeustInvitation(
+                    api: HoldyAPI.RequestInvitaion(),
+                    id: id,
+                    decodingType: InvitaionResponse.self
+                )
+                
+                response.asObservable()
+                    .subscribe(onNext: { response in
+                        #if DEBUG
+                        print(response)
+                        #endif
+                    })
+                    .disposed(by: disposeBag)
+            }
         }
     }
 }

--- a/holdy-iOS/Presentation/GroupDetail/View/CustomView/BottomSheetContentViewController.swift
+++ b/holdy-iOS/Presentation/GroupDetail/View/CustomView/BottomSheetContentViewController.swift
@@ -91,6 +91,11 @@ final class BottomSheetContentViewController: UIViewController {
     private var participantsInfo: Observable<[ParticipantsDescribing]>!
     private let disposeBag = DisposeBag()
     
+    // MARK: - 카카오 공유에 전달하기 위한 프로퍼티
+    private var sharePlace = ""
+    private var shareStartDate = ""
+    private var shareID = ""
+    
     // MARK: - Initializers
     convenience init(
         viewModel: GroupDetailViewModel,
@@ -257,11 +262,19 @@ final class BottomSheetContentViewController: UIViewController {
     
     private func configureInviteButton() {
         inviteButton.rx.tap
-            .subscribe(onNext: {
+            .withUnretained(self)
+            .subscribe(onNext: { viewController, _ in
                 let templateID: Int64 = 81345
                  
                 if ShareApi.isKakaoTalkSharingAvailable() {
-                    ShareApi.shared.shareCustom(templateId: templateID) { shareResult, error in
+                    ShareApi.shared.shareCustom(
+                        templateId: templateID,
+                        templateArgs: [
+                            "title": viewController.sharePlace,
+                            "content": viewController.shareStartDate,
+                            "moim_id": viewController.shareID
+                        ]
+                    ) { shareResult, error in
                         if let error = error {
                             #if DEBUG
                             print(error)
@@ -285,6 +298,14 @@ final class BottomSheetContentViewController: UIViewController {
                 }
             })
             .disposed(by: disposeBag)
+    }
+}
+
+extension BottomSheetContentViewController {
+    func configureShareTemplateArgs(id: String, place: String, date: String) {
+        self.shareID = id
+        self.sharePlace = place
+        self.shareStartDate = date
     }
 }
 

--- a/holdy-iOS/Presentation/GroupDetail/View/CustomView/BottomSheetContentViewController.swift
+++ b/holdy-iOS/Presentation/GroupDetail/View/CustomView/BottomSheetContentViewController.swift
@@ -113,7 +113,6 @@ final class BottomSheetContentViewController: UIViewController {
         
         render()
         configureCollectionView()
-        configureGuestPage()
         bind()
     }
     
@@ -205,7 +204,7 @@ final class BottomSheetContentViewController: UIViewController {
     }
     
     private func configureGuestPage() {
-        guard UserDefaultsManager.id == viewModel.hostID else {
+        guard UserDefaultsManager.id != viewModel.hostID else {
             return
         }
         
@@ -249,13 +248,17 @@ final class BottomSheetContentViewController: UIViewController {
             .bind(to: participantsCollectionview.rx.items(
                 cellIdentifier: String(describing: ParticipantCell.self),
                 cellType: ParticipantCell.self
-            )) { _, item, cell in
+            )) { [weak self] _, item, cell in
+                guard let self = self else { return }
+                
                 cell.configureContent(
                     imageURL: item.profileImageUrl,
                     name: item.nickname,
                     group: item.group,
                     id: item.id
                 )
+                
+                self.configureGuestPage()
             }
             .disposed(by: disposeBag)
     }

--- a/holdy-iOS/Presentation/GroupDetail/View/GroupDetailViewController.swift
+++ b/holdy-iOS/Presentation/GroupDetail/View/GroupDetailViewController.swift
@@ -85,7 +85,6 @@ final class GroupDetailViewController: UIViewController {
         super.viewDidLoad()
 
         render()
-        configureGuestPage()
     }
 
     private func render() {
@@ -174,7 +173,7 @@ final class GroupDetailViewController: UIViewController {
     }
     
     private func configureGuestPage() {
-        guard UserDefaultsManager.id == viewModel.hostID else {
+        guard UserDefaultsManager.id != viewModel.hostID else {
             return
         }
         
@@ -208,6 +207,8 @@ final class GroupDetailViewController: UIViewController {
                     place: groupInfo.place.address,
                     date: startDate
                 )
+                
+                self.configureGuestPage()
             })
             .disposed(by: disposeBag)
     }

--- a/holdy-iOS/Presentation/GroupDetail/View/GroupDetailViewController.swift
+++ b/holdy-iOS/Presentation/GroupDetail/View/GroupDetailViewController.swift
@@ -202,7 +202,12 @@ final class GroupDetailViewController: UIViewController {
                 let startDate = self.attributeStartDateLabel(groupInfo.startDate)
                 let endDate = self.attributeEndDateLabel(groupInfo.endDate)
                 self.dateLabel.text = "\(startDate) ~ \(endDate)"
-
+                
+                self.contentViewController.configureShareTemplateArgs(
+                    id: "\(self.viewModel.id)",
+                    place: groupInfo.place.address,
+                    date: startDate
+                )
             })
             .disposed(by: disposeBag)
     }

--- a/holdy-iOS/Presentation/Home/View/GroupListViewController.swift
+++ b/holdy-iOS/Presentation/Home/View/GroupListViewController.swift
@@ -67,6 +67,21 @@ final class GroupListViewController: UIViewController {
         self.coordinator = coordinator
         
         bind()
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(refresh),
+            name: NSNotification.Name("EnterForeground"),
+            object: nil
+        )
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(
+            self,
+            name: NSNotification.Name("EnterForeground"),
+            object: nil
+        )
     }
     
     // MARK: - Lifecycle Methods
@@ -84,6 +99,11 @@ final class GroupListViewController: UIViewController {
     }
     
     // MARK: - Methods
+    @objc
+    private func refresh() {
+        listCollectionview.reloadData()
+    }
+    
     private func configureCollectionView() {
         listCollectionview.register(cellClass: GroupListCell.self)
         listCollectionview.delegate = self


### PR DESCRIPTION
# 배경
기존에는 카카오톡 공유만 가능하고 초대 API를 사용하지 않았으나, 이를 사용해 모임을 추가할 수 있도록 추가 구현

# 작업 내용
## 1. 카카오톡 공유를 통한 데이터 전달 및 메시지 커스텀
카카오톡의 경우 기존 템플릿을 그대로 사용해서 데이터를 전달할 수도 있지만 이를 커스텀할 수도 있었습니다. 저희의 경우 모임 id(`moim_id`)를 보내줘야 했기에 커스텀을 사용했습니다. 

이는 [카카오 Developers](https://developers.kakao.com/) > 내 애플리케이션 > 메시지 > 메시지 템플릿에서 커스텀할 수 있고, 커스텀을 하게 되면 이에 따라 id가 부여됩니다. 추후 전달을 할 때 해당 템플릿 id와 같이 보내주면 됩니다. 
```swift
let templateID: Int64 = {메시지 템플릿 아이디를 적어주면 됩니다}
 
if ShareApi.isKakaoTalkSharingAvailable() {
    ShareApi.shared.shareCustom(
        templateId: templateID,
        templateArgs: [
            "title": viewController.sharePlace,
            "content": viewController.shareStartDate,
            "moim_id": viewController.shareID
        ]
    ) { shareResult, error in
        if let error = error {
            #if DEBUG
            print(error)
            #endif
        } else {
            if let shareResult = shareResult {
                UIApplication.shared.open(shareResult.url)
            }
        }
    }
}
```

그리고 모임 id의 경우 커스텀을 해줄 때 버튼 탭에서 Scheme을 설정해주면 됩니다. 
<img width="440" alt="스크린샷 2022-10-03 오후 8 31 23" src="https://user-images.githubusercontent.com/90880660/193567017-f9fc82d4-6ebc-48b2-9327-799916f1835b.png">
이렇게 넣어주면 추후 `SceneDelegate`의 `func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>)` 메서드의 url에서 쿼리 형태로 붙어서 전달되게 됩니다.

여기서 쿼리 값을 받아서 초대 엔드포인트를 통해 통신을 하는 방식으로 구현했습니다. 

## 2. 게스트 페이지를 구현하는 방식을 수정했습니다. 
기존에는 viewDidLoad에서 게스트인지 아닌지를 파악하는 로직으로 구현을 했습니다. 하지만 서버 통신을 통해 hostID를 알게 됐기에, viewDidLoad 시점에서는 hostID를 파악하지 못하는 문제가 있었습니다. 따라서 통신이 종료된 후 게스트 페이지 구성을 할 수 있도록 수정했습니다. 

## 3. 카톡 공유를 통해 앱을 열었을 경우 refresh
카톡 공유를 받고 이를 통해 앱을 열어 정상적으로 모임이 추가됐음에도, collectionView의 데이터를 reload하지 않아 리프레쉬 되지 않는 문제가 있었습니다. 다른 앱에서 다시 돌아올 때에도 viewWillAppear가 호출되지 않을까 했지만 해당 메서드는 호출되지 않았고, viewDidAppear` 또한 호출되지 않았습니다. 따라서 NotificationCenter를 사용해, SceneDelegate의 `sceneWillEnterForeground` 메서드에서 post를 하고 `GroupListViewController`에서 이를 받아 앱이 foreground로 왔을 때 reload해줄 수 있도록 했습니다. 

# 테스트 방법
시간 관계 상 따로 테스트 코드를 짜지 않고 시뮬레이터를 통해 직접 확인
- 카톡 공유 확인을 위해 실기기 확인

# 리뷰 노트
- 카톡 공유를 통해 초대를 받았을 때 이에 대한 메시지를 보여주는 방식 추가 구현 필요

# 스크린샷
생략

